### PR TITLE
Update REST service discovery & Hazelcast port fallback in DNS discovery

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,13 +51,19 @@ maven, Gradle, sbt or similar tools, this is as easy as adding it to the build c
 ----
 
 This fragment will add the discovery plugin as well as necessary transitive dependencies into your application classpath. The
-second step is to configure the discovery plugin inside of your Hazelcast configuration.
+second step is to configure the discovery plugin inside of your Hazelcast configuration. You have 3 options to configure the plugin:
+
+1. Set a namespace ( <property name="namespace">MY-KUBERNETES-NAMESPACE</property>), if no property is set the default namespace will be used
+2. Set a service name ( <property name="service-name">MY-SERVICE-NAME</property>), scans all endpoints (pods) connected by a service (query is combined with namespace)
+3. Set a service label & value (<property name="service-label-name">cluster01</property> & <property name="service-label-value">true</property>). If no endpoints by service name were found, endpoints were queried by service label name & value (in namespace). You can have many services and group your nodes by labels.
+
 
 [source,xml]
 ----
 <hazelcast>
   <properties>
     <!-- at the moment the discovery needs to be activated explicitly -->
+     <property name="hazelcast.rest.enabled">true</property>
     <property name="hazelcast.discovery.enabled">true</property>
   </properties>
 
@@ -75,6 +81,8 @@ second step is to configure the discovery plugin inside of your Hazelcast config
           <properties>
             <!-- configure discovery service API lookup -->
             <property name="service-name">MY-SERVICE-NAME</property>
+             <property name="service-label-name">cluster01</property>
+              <property name="service-label-value">true</property>
             <property name="namespace">MY-KUBERNETES-NAMESPACE</property>
           </properties>
         </discovery-strategy>

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/DnsEndpointResolver.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/DnsEndpointResolver.java
@@ -16,16 +16,13 @@
  */
 package com.noctarius.hazelcast.kubernetes;
 
+import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
-import org.xbill.DNS.Lookup;
-import org.xbill.DNS.Record;
-import org.xbill.DNS.SRVRecord;
-import org.xbill.DNS.TextParseException;
-import org.xbill.DNS.Type;
+import org.xbill.DNS.*;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -71,7 +68,7 @@ final class DnsEndpointResolver extends HazelcastKubernetesDiscoveryStrategy.End
                 //      Address: 10.1.9.33
                 SRVRecord srv = (SRVRecord) records[0];
                 InetAddress[] inetAddress = getAllAdresses(srv);
-                int port = srv.getPort();
+                int port = getHazelcastPort(srv.getPort());
 
                 for (InetAddress i : inetAddress) {
                     Address address = new Address(i, port);
@@ -93,6 +90,11 @@ final class DnsEndpointResolver extends HazelcastKubernetesDiscoveryStrategy.End
         } catch (UnknownHostException e) {
             throw new RuntimeException("Could not resolve services via DNS", e);
         }
+    }
+
+    private int getHazelcastPort(int port){
+        if(port>0) return port;
+        return NetworkConfig.DEFAULT_PORT;
     }
 
     private InetAddress[] getAllAdresses(SRVRecord srv) throws UnknownHostException {

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -28,10 +28,7 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_SYSTEM_PREFIX;
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.NAMESPACE;
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS;
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
+import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.*;
 
 final class HazelcastKubernetesDiscoveryStrategy
         implements DiscoveryStrategy {
@@ -43,16 +40,16 @@ final class HazelcastKubernetesDiscoveryStrategy
     HazelcastKubernetesDiscoveryStrategy(ILogger logger, Map<String, Comparable> properties) {
         String serviceDns = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_DNS);
         String serviceName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_NAME);
-        String namespace = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE);
+        String serviceLabel = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_NAME);
+        String serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE,"true");
+        String namespace = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE,getNamespaceOrDefault());
 
-        if (serviceDns == null && (serviceName == null || namespace == null)) {
-            throw new RuntimeException(
-                    "For kubernetes discovery either 'service-dns' or " + "'service-name' and 'namespace' must be set");
-        }
 
         logger.info("Kubernetes Discovery properties: { "
                 + "service-dns: " + serviceDns + ", "
                 + "service-name: " + serviceName + ", "
+                + "service-label: " + serviceLabel + ", "
+                + "service-label-value: " + serviceLabelValue + ", "
                 + "namespace: " + namespace
                 + "}");
 
@@ -60,10 +57,21 @@ final class HazelcastKubernetesDiscoveryStrategy
         if (serviceDns != null) {
             endpointResolver = new DnsEndpointResolver(logger, serviceDns);
         } else {
-            endpointResolver = new ServiceEndpointResolver(logger, serviceName, namespace);
+            endpointResolver = new ServiceEndpointResolver(logger, serviceName, serviceLabel, serviceLabelValue, namespace);
         }
         logger.info("Kubernetes Discovery activated resolver: " + endpointResolver.getClass().getSimpleName());
         this.endpointResolver = endpointResolver;
+    }
+
+    private String getNamespaceOrDefault() {
+        String namespace = System.getenv("KUBERNETES_NAMESPACE");
+        if (namespace == null) {
+            namespace = System.getenv("OPENSHIFT_BUILD_NAMESPACE");
+            if (namespace == null) {
+                namespace = "default";
+            }
+        }
+        return namespace;
     }
 
     public void start() {
@@ -82,8 +90,8 @@ final class HazelcastKubernetesDiscoveryStrategy
         return getOrDefault(properties, prefix, property, null);
     }
 
-    protected  <T extends Comparable> T getOrDefault(Map<String, Comparable> properties, String prefix,
-                                                     PropertyDefinition property, T defaultValue) {
+    protected <T extends Comparable> T getOrDefault(Map<String, Comparable> properties, String prefix,
+                                                    PropertyDefinition property, T defaultValue) {
         if (property == null) {
             return defaultValue;
         }

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -22,10 +22,9 @@ import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -36,11 +35,12 @@ public class HazelcastKubernetesDiscoveryStrategyFactory implements DiscoveryStr
     private static final Collection<PropertyDefinition> PROPERTY_DEFINITIONS;
 
     static {
-        List<PropertyDefinition> propertyDefinitions = new ArrayList<PropertyDefinition>();
-        propertyDefinitions.add(KubernetesProperties.SERVICE_DNS);
-        propertyDefinitions.add(KubernetesProperties.SERVICE_NAME);
-        propertyDefinitions.add(KubernetesProperties.NAMESPACE);
-        PROPERTY_DEFINITIONS = Collections.unmodifiableCollection(propertyDefinitions);
+        PROPERTY_DEFINITIONS = Collections.unmodifiableCollection(Arrays.asList(
+                KubernetesProperties.SERVICE_DNS,
+                KubernetesProperties.SERVICE_NAME,
+                KubernetesProperties.NAMESPACE,
+                KubernetesProperties.SERVICE_LABEL_NAME,
+                KubernetesProperties.SERVICE_LABEL_VALUE));
     }
 
     public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
@@ -30,9 +30,9 @@ public final class KubernetesProperties {
 
     /**
      * <p>Configuration System Environment Prefix: <tt>hazelcast.kubernetes.</tt></p>
-     * Defines the prefix for system environment variables and JVM command line parameters.<br/>
+     * Defines the prefix for system environment variables and JVM command line parameters.<br>
      * Defining or overriding properties as JVM parameters or using the system environment, those
-     * properties need to be prefixed to prevent collision on property names.<br/>
+     * properties need to be prefixed to prevent collision on property names.<br>
      * Example: {@link #SERVICE_DNS} will be:
      * <pre>
      *     -Dhazelcast.kubernetes.service-dns=value
@@ -49,7 +49,7 @@ public final class KubernetesProperties {
     /**
      * <p>Configuration key: <tt>service-dns</tt></p>
      * Defines the DNS service lookup domain. This is defined as something similar
-     * to <tt>my-svc.my-namespace.svc.cluster.local</tt>.<br/>
+     * to <tt>my-svc.my-namespace.svc.cluster.local</tt>.<br>
      * For more information please refer to the official documentation of the Kubernetes DNS addon,
      * <a href="https://github.com/kubernetes/kubernetes/tree/v1.0.6/cluster/addons/dns">here</a>.
      */
@@ -60,6 +60,16 @@ public final class KubernetesProperties {
      * Defines the service name of the POD to lookup through the Service Discovery REST API of Kubernetes.
      */
     public static final PropertyDefinition SERVICE_NAME = property("service-name", STRING);
+    /**
+     * <p>Configuration key: <tt>service-label-name</tt></p>
+     * Defines the service label to lookup through the Service Discovery REST API of Kubernetes.
+     */
+    public static final PropertyDefinition SERVICE_LABEL_NAME = property("service-label-name", STRING);
+    /**
+     * <p>Configuration key: <tt>service-label-value</tt></p>
+     * Defines the service label value to lookup through the Service Discovery REST API of Kubernetes.
+     */
+    public static final PropertyDefinition SERVICE_LABEL_VALUE= property("service-label-value", STRING);
 
     /**
      * <p>Configuration key: <tt>namespace</tt></p>


### PR DESCRIPTION
- Update REST service discovery to query by labe & value or only by namespace
- use default Hazelcast port in DNS discovery when query returns 0