### PR TITLE
Traversing through complete set of returned DNS records

### DIFF
--- a/src/main/java/com/noctarius/hazelcast/kubernetes/DnsEndpointResolver.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/DnsEndpointResolver.java
@@ -30,9 +30,7 @@ import org.xbill.DNS.Type;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 final class DnsEndpointResolver
         extends HazelcastKubernetesDiscoveryStrategy.EndpointResolver {
@@ -56,7 +54,7 @@ final class DnsEndpointResolver
                 return Collections.emptyList();
             }
 
-            List<DiscoveryNode> discoveredNodes = new ArrayList<DiscoveryNode>();
+            Set<Address> discoveredAddresses = new HashSet<Address>();
 
             for (Record record : records) {
                 // nslookup u219692-hazelcast.u219692-hazelcast.svc.cluster.local 172.30.0.1
@@ -79,12 +77,19 @@ final class DnsEndpointResolver
                     if (LOGGER.isFinestEnabled()) {
                         LOGGER.finest("Found node ip-address is: " + address);
                     }
-                    discoveredNodes.add(new SimpleDiscoveryNode(address));
+                    discoveredAddresses.add(address);
                 }
 
             }
-            if (discoveredNodes.isEmpty()){
+            if (discoveredAddresses.isEmpty()) {
                 LOGGER.warning("Could not find any service for serviceDns '" + serviceDns + "' failed");
+                return Collections.EMPTY_LIST;
+            }
+
+            List<DiscoveryNode> discoveredNodes = new ArrayList<DiscoveryNode>(discoveredAddresses.size());
+
+            for (Address address : discoveredAddresses) {
+                discoveredNodes.add(new SimpleDiscoveryNode(address));
             }
 
             return discoveredNodes;

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/DnsEndpointResolver.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/DnsEndpointResolver.java
@@ -58,9 +58,7 @@ final class DnsEndpointResolver
 
             List<DiscoveryNode> discoveredNodes = new ArrayList<DiscoveryNode>();
 
-            if (records.length > 0) {
-                // Get only the first record, because all of them have the same name
-                // Example:
+            for (Record record : records) {
                 // nslookup u219692-hazelcast.u219692-hazelcast.svc.cluster.local 172.30.0.1
                 //      Server:         172.30.0.1
                 //      Address:        172.30.0.1#53
@@ -71,7 +69,7 @@ final class DnsEndpointResolver
                 //      Address: 10.1.5.28
                 //      Name:   u219692-hazelcast.u219692-hazelcast.svc.cluster.local
                 //      Address: 10.1.9.33
-                SRVRecord srv = (SRVRecord) records[0];
+                SRVRecord srv = (SRVRecord) record;
                 InetAddress[] inetAddress = getAllAddresses(srv);
                 int port = getHazelcastPort(srv.getPort());
 
@@ -84,9 +82,9 @@ final class DnsEndpointResolver
                     discoveredNodes.add(new SimpleDiscoveryNode(address));
                 }
 
-            } else {
+            }
+            if (discoveredNodes.isEmpty()){
                 LOGGER.warning("Could not find any service for serviceDns '" + serviceDns + "' failed");
-                return Collections.emptyList();
             }
 
             return discoveredNodes;


### PR DESCRIPTION
In my case (GCE Kubernetes 1.3.5), lookup returns several records. To make things even worst, order of the records is not guaranteed. This lead to situation when all Hazecast nodes were separated in several not intersecting buckets. In edge case, node could discover only itself.