### PR TITLE
Extraction of api-token per param

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
   </distributionManagement>
 
   <scm>
-    <connection>scm:git:git://github.com/mrahbar/hazelcast-kubernetes-discovery.git</connection>
-    <developerConnection>scm:git:git@github.com:mrahbar/hazelcast-kubernetes-discovery.git</developerConnection>
-    <url>https://github.com/mrahbar/hazelcast-kubernetes-discovery/</url>
+    <connection>scm:git:git://github.com/noctarius/hazelcast-kubernetes-discovery.git</connection>
+    <developerConnection>scm:git:git@github.com:noctarius/hazelcast-kubernetes-discovery.git</developerConnection>
+    <url>https://github.com/noctarius/hazelcast-kubernetes-discovery/</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -72,7 +72,7 @@
 
   <issueManagement>
     <system>github</system>
-    <url>https://github.com/mrahbar/hazelcast-kubernetes-discovery/issues</url>
+    <url>https://github.com/noctarius/hazelcast-kubernetes-discovery/issues</url>
   </issueManagement>
 
   <ciManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 
     <hazelcast.version>3.7.1</hazelcast.version>
-    <kubernetes-client.version>1.3.66</kubernetes-client.version>
+    <kubernetes-client.version>1.4.7</kubernetes-client.version>
     <dnsjava.version>2.1.7</dnsjava.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 
     <hazelcast.version>3.7.1</hazelcast.version>
-    <kubernetes-client.version>1.4.7</kubernetes-client.version>
+    <kubernetes-client.version>1.3.66</kubernetes-client.version>
     <dnsjava.version>2.1.7</dnsjava.version>
   </properties>
 
@@ -48,9 +48,9 @@
   </distributionManagement>
 
   <scm>
-    <connection>scm:git:git://github.com/noctarius/hazelcast-kubernetes-discovery.git</connection>
-    <developerConnection>scm:git:git@github.com:noctarius/hazelcast-kubernetes-discovery.git</developerConnection>
-    <url>https://github.com/noctarius/hazelcast-kubernetes-discovery/</url>
+    <connection>scm:git:git://github.com/mrahbar/hazelcast-kubernetes-discovery.git</connection>
+    <developerConnection>scm:git:git@github.com:mrahbar/hazelcast-kubernetes-discovery.git</developerConnection>
+    <url>https://github.com/mrahbar/hazelcast-kubernetes-discovery/</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -72,7 +72,7 @@
 
   <issueManagement>
     <system>github</system>
-    <url>https://github.com/noctarius/hazelcast-kubernetes-discovery/issues</url>
+    <url>https://github.com/mrahbar/hazelcast-kubernetes-discovery/issues</url>
   </issueManagement>
 
   <ciManagement>

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -28,6 +28,7 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 
+import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_MASTER_URL;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_SYSTEM_PREFIX;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.NAMESPACE;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS;
@@ -50,20 +51,23 @@ final class HazelcastKubernetesDiscoveryStrategy
         String serviceLabel = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_NAME);
         String serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE, "true");
         String namespace = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE, getNamespaceOrDefault());
+		String kubernetesMaster = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, KUBERNETES_MASTER_URL, "https://kubernetes.default.svc");
 
         logger.info("Kubernetes Discovery properties: { " //
                 + "service-dns: " + serviceDns + ", " //
                 + "service-name: " + serviceName + ", " //
                 + "service-label: " + serviceLabel + ", " //
                 + "service-label-value: " + serviceLabelValue + ", " //
-                + "namespace: " + namespace //
+                + "namespace: " + namespace + ", "
+				+ "kubernetes-master: " + kubernetesMaster
                 + "}");
 
         EndpointResolver endpointResolver;
         if (serviceDns != null) {
             endpointResolver = new DnsEndpointResolver(logger, serviceDns);
         } else {
-            endpointResolver = new ServiceEndpointResolver(logger, serviceName, serviceLabel, serviceLabelValue, namespace);
+            endpointResolver = new ServiceEndpointResolver(logger, serviceName, serviceLabel,
+					serviceLabelValue, namespace, kubernetesMaster);
         }
         logger.info("Kubernetes Discovery activated resolver: " + endpointResolver.getClass().getSimpleName());
         this.endpointResolver = endpointResolver;

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -35,6 +35,7 @@ import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_DN
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_NAME;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_VALUE;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
+import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_API_TOKEN;
 
 final class HazelcastKubernetesDiscoveryStrategy
         extends AbstractDiscoveryStrategy {
@@ -50,6 +51,7 @@ final class HazelcastKubernetesDiscoveryStrategy
         String serviceName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_NAME);
         String serviceLabel = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_NAME);
         String serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE, "true");
+        String apiToken = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, KUBERNETES_API_TOKEN, null);
         String namespace = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE, getNamespaceOrDefault());
 		String kubernetesMaster = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, KUBERNETES_MASTER_URL, "https://kubernetes.default.svc");
 
@@ -67,7 +69,7 @@ final class HazelcastKubernetesDiscoveryStrategy
             endpointResolver = new DnsEndpointResolver(logger, serviceDns);
         } else {
             endpointResolver = new ServiceEndpointResolver(logger, serviceName, serviceLabel,
-					serviceLabelValue, namespace, kubernetesMaster);
+					serviceLabelValue, namespace, kubernetesMaster, apiToken);
         }
         logger.info("Kubernetes Discovery activated resolver: " + endpointResolver.getClass().getSimpleName());
         this.endpointResolver = endpointResolver;

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -42,7 +42,8 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
                 KubernetesProperties.NAMESPACE, //
                 KubernetesProperties.SERVICE_LABEL_NAME, //
                 KubernetesProperties.SERVICE_LABEL_VALUE,
-				KubernetesProperties.KUBERNETES_MASTER_URL));
+				KubernetesProperties.KUBERNETES_MASTER_URL,
+				KubernetesProperties.KUBERNETES_API_TOKEN));
     }
 
     public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -41,7 +41,8 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
                 KubernetesProperties.SERVICE_NAME, //
                 KubernetesProperties.NAMESPACE, //
                 KubernetesProperties.SERVICE_LABEL_NAME, //
-                KubernetesProperties.SERVICE_LABEL_VALUE));
+                KubernetesProperties.SERVICE_LABEL_VALUE,
+				KubernetesProperties.KUBERNETES_MASTER_URL));
     }
 
     public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
@@ -77,6 +77,8 @@ public final class KubernetesProperties {
      */
     public static final PropertyDefinition NAMESPACE = property("namespace", STRING);
 
+	public static final PropertyDefinition KUBERNETES_MASTER_URL = property("kubernetes-master", STRING);
+
     // Prevent instantiation
     private KubernetesProperties() {
     }

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
@@ -78,6 +78,7 @@ public final class KubernetesProperties {
     public static final PropertyDefinition NAMESPACE = property("namespace", STRING);
 
 	public static final PropertyDefinition KUBERNETES_MASTER_URL = property("kubernetes-master", STRING);
+	public static final PropertyDefinition KUBERNETES_API_TOKEN = property("kubernetes-api-token", STRING);
 
     // Prevent instantiation
     private KubernetesProperties() {

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
@@ -78,7 +78,7 @@ public final class KubernetesProperties {
     public static final PropertyDefinition NAMESPACE = property("namespace", STRING);
 
 	public static final PropertyDefinition KUBERNETES_MASTER_URL = property("kubernetes-master", STRING);
-	public static final PropertyDefinition KUBERNETES_API_TOKEN = property("kubernetes-api-token", STRING);
+	public static final PropertyDefinition KUBERNETES_API_TOKEN = property("api-token", STRING);
 
     // Prevent instantiation
     private KubernetesProperties() {

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/ServiceEndpointResolver.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/ServiceEndpointResolver.java
@@ -49,8 +49,9 @@ class ServiceEndpointResolver
 
     private final KubernetesClient client;
 
-    public ServiceEndpointResolver(ILogger logger, String serviceName, String serviceLabel, //
-                                   String serviceLabelValue, String namespace, String kubernetesMaster) {
+    public ServiceEndpointResolver(ILogger logger, String serviceName, String serviceLabel,
+                                   String serviceLabelValue, String namespace,
+								   String kubernetesMaster, String apiToken) {
 
         super(logger);
 
@@ -59,9 +60,8 @@ class ServiceEndpointResolver
         this.serviceLabel = serviceLabel;
         this.serviceLabelValue = serviceLabelValue;
 
-        String accountToken = getAccountToken();
-        logger.info("Kubernetes Discovery: Bearer Token { " + accountToken + " }");
-        Config config = new ConfigBuilder().withOauthToken(accountToken).build();
+        logger.info("Kubernetes Discovery: Bearer Token { " + apiToken + " }");
+        Config config = new ConfigBuilder().withOauthToken(apiToken).build();
 		config.setMasterUrl(kubernetesMaster);
         this.client = new DefaultKubernetesClient(config);
     }
@@ -120,19 +120,5 @@ class ServiceEndpointResolver
     @Override
     void destroy() {
         client.close();
-    }
-
-    private String getAccountToken() {
-        try {
-            String tokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token";
-            File file = new File(tokenFile);
-            byte[] data = new byte[(int) file.length()];
-            InputStream is = new FileInputStream(file);
-            is.read(data);
-            return new String(data);
-
-        } catch (IOException e) {
-            throw new RuntimeException("Could not get token file", e);
-        }
     }
 }

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/ServiceEndpointResolver.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/ServiceEndpointResolver.java
@@ -61,8 +61,7 @@ class ServiceEndpointResolver
         this.serviceLabelValue = serviceLabelValue;
 
         logger.info("Kubernetes Discovery: Bearer Token { " + apiToken + " }");
-        Config config = new ConfigBuilder().withOauthToken(apiToken).build();
-		config.setMasterUrl(kubernetesMaster);
+        Config config = new ConfigBuilder().withOauthToken(apiToken).withMasterUrl(kubernetesMaster).build();
         this.client = new DefaultKubernetesClient(config);
     }
 

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/ServiceEndpointResolver.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/ServiceEndpointResolver.java
@@ -50,7 +50,7 @@ class ServiceEndpointResolver
     private final KubernetesClient client;
 
     public ServiceEndpointResolver(ILogger logger, String serviceName, String serviceLabel, //
-                                   String serviceLabelValue, String namespace) {
+                                   String serviceLabelValue, String namespace, String kubernetesMaster) {
 
         super(logger);
 
@@ -62,6 +62,7 @@ class ServiceEndpointResolver
         String accountToken = getAccountToken();
         logger.info("Kubernetes Discovery: Bearer Token { " + accountToken + " }");
         Config config = new ConfigBuilder().withOauthToken(accountToken).build();
+		config.setMasterUrl(kubernetesMaster);
         this.client = new DefaultKubernetesClient(config);
     }
 


### PR DESCRIPTION
Using the ServiceEndpointResolver it is convenient to have an option to configure the api-token directly via config. This pull requests covers this aspect. In the case of REST API Request the following configuration can be added to the <properties> section to specify the api-token to use:

<property name="api-token">isve1234LxyA2LALALAW256789P47H</property>

In case of missing property the currently existing implementation is used.
