### PR TITLE
Avoid caching temporary DNS lookup failures

### DIFF
--- a/src/main/java/com/noctarius/hazelcast/kubernetes/DnsEndpointResolver.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/DnsEndpointResolver.java
@@ -47,6 +47,7 @@ final class DnsEndpointResolver
     List<DiscoveryNode> resolve() {
         try {
             Lookup lookup = new Lookup(serviceDns, Type.SRV);
+            lookup.setCache(null); // Avoid caching temporary DNS lookup failures indefinitely in global cache
             Record[] records = lookup.run();
 
             if (lookup.getResult() != Lookup.SUCCESSFUL) {


### PR DESCRIPTION
dnsjava uses a global DNS lookup cache. If the service DNS returns failures temporarily, these failure responses will be cached with an indefinite TTL by default, effectively disabling the Kubernetes service DNS lookup until the node is restarted.

This fix turns off the cache to get a fresh, current DNS response for each request.