### PR TITLE
Configurable DNS timeout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -146,6 +146,7 @@ link:https://github.com/kubernetes/kubernetes/tree/v1.0.6/cluster/addons/dns[Kub
           <properties>
             <!-- configure discovery service API lookup -->
             <property name="service-dns">MY-SERVICE-DNS-NAME</property>
+            <property name="service-dns-timeout">10</property>
           </properties>
         </discovery-strategy>
       </discovery-strategies>

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -33,6 +33,7 @@ import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.KUBERNETES
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_SYSTEM_PREFIX;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.NAMESPACE;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS;
+import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS_TIMEOUT;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_NAME;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_VALUE;
 import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
@@ -49,6 +50,7 @@ final class HazelcastKubernetesDiscoveryStrategy
         super(logger, properties);
 
         String serviceDns = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_DNS);
+        int serviceDnsTimeout = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_DNS_TIMEOUT, 5);
         String serviceName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_NAME);
         String serviceLabel = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_NAME);
         String serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE, "true");
@@ -58,6 +60,7 @@ final class HazelcastKubernetesDiscoveryStrategy
 
         logger.info("Kubernetes Discovery properties: { " //
                 + "service-dns: " + serviceDns + ", " //
+                + "service-dns-timeout: " + serviceDnsTimeout + ", " //
                 + "service-name: " + serviceName + ", " //
                 + "service-label: " + serviceLabel + ", " //
                 + "service-label-value: " + serviceLabelValue + ", " //
@@ -65,7 +68,7 @@ final class HazelcastKubernetesDiscoveryStrategy
 
         EndpointResolver endpointResolver;
         if (serviceDns != null) {
-            endpointResolver = new DnsEndpointResolver(logger, serviceDns);
+            endpointResolver = new DnsEndpointResolver(logger, serviceDns, serviceDnsTimeout);
         } else {
             endpointResolver = new ServiceEndpointResolver(logger, serviceName, serviceLabel, serviceLabelValue, namespace,
                     kubernetesMaster, apiToken);

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
 import com.hazelcast.core.TypeConverter;
 
+import static com.hazelcast.config.properties.PropertyTypeConverter.INTEGER;
 import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
 /**
@@ -54,6 +55,12 @@ public final class KubernetesProperties {
      * <a href="https://github.com/kubernetes/kubernetes/tree/v1.0.6/cluster/addons/dns">here</a>.
      */
     public static final PropertyDefinition SERVICE_DNS = property("service-dns", STRING);
+
+    /**
+     * <p>Configuration key: <tt>service-dns-timeout</tt></p>
+     * Defines the DNS service lookup timeout in seconds.
+     */
+    public static final PropertyDefinition SERVICE_DNS_TIMEOUT = property("service-dns-timeout", INTEGER);
 
     /**
      * <p>Configuration key: <tt>service-name</tt></p>


### PR DESCRIPTION
Adds a configuration property to set the DNS timeout. By default, dnsjava uses a globally shared default resolver, which in turn defaults to 5s. This PR makes this value configurable and avoids using the globally shared dnsjava resolver, which might be a good thing by itself to avoid interference with other code using dnsjava and changing global defaults. Together with the caching PR #22, this should make the plugin more resilient against stray DNS issues or slow responses.